### PR TITLE
Improve preview rendering

### DIFF
--- a/Packages/com.chisel.editor/Chisel/Editor/Editor/MaterialBrowser/ChiselMaterialBrowserUtilities.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Editor/MaterialBrowser/ChiselMaterialBrowserUtilities.cs
@@ -84,7 +84,13 @@ namespace Chisel.Editors
             if( usingLabel && searchLabel == string.Empty )
                 Debug.LogError( $"usingLabel set to true, but no search term was given. This may give undesired results." );
 
-            materials?.Clear();
+            materials.ForEach(e =>
+            {
+                e.Dispose();
+                e = null;
+            });
+
+            materials.Clear();
 
             ChiselMaterialThumbnailRenderer.CancelAll();
 
@@ -92,8 +98,6 @@ namespace Chisel.Editors
             string search = usingLabel ? $"l:{searchLabel} {searchText}" : $"{searchText}";
 
             string[] guids = AssetDatabase.FindAssets( $"t:Material {search}" );
-
-            AssetPreview.SetPreviewTextureCacheSize( materials.Capacity = guids.Length + 1 );
 
             // assemble preview tiles
             foreach( var id in guids )

--- a/Packages/com.chisel.editor/Chisel/Editor/Editor/MaterialBrowser/ChiselMaterialBrowserWindow.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Editor/MaterialBrowser/ChiselMaterialBrowserWindow.cs
@@ -54,8 +54,8 @@ namespace Chisel.Editors
                 e = null;
             } );
 
-            m_Tiles  = null;
-            m_Labels = null;
+            m_Tiles.Clear();
+            m_Labels.Clear();
 
             AssetDatabase.ReleaseCachedFileHandles();
             EditorUtility.UnloadUnusedAssetsImmediate( true );
@@ -332,9 +332,10 @@ namespace Chisel.Editors
 
             tileScrollPos = GUI.BeginScrollView( m_ScrollViewRect, tileScrollPos, m_TileContentRect, false, true );
             {
-                float xOffset = 0;
-                float yOffset = 0;
-                int   row     = 0;
+                float xOffset      = 0;
+                float yOffset      = 0;
+                int   row          = 0;
+                int   previewCount = 0;
 
                 foreach( var entry in m_Tiles )
                 {
@@ -352,11 +353,13 @@ namespace Chisel.Editors
                         m_TileContentRect.width  = tileSize - 2;
                         m_TileContentRect.height = tileSize - 4;
 
-                        m_TileContentText.image   = m_Tiles[idx].Preview;
-                        m_TileContentText.tooltip = $"{m_Tiles[idx].materialName}\n\nClick to apply to the currently selected surface.";
-
-                        if( m_Tiles[idx].CheckVisible( yOffset, tileSize, tileScrollPos, tileScrollViewHeight ) )
+                        if( m_Tiles[idx].CheckVisible( yOffset, tileSize, tileScrollPos, m_ScrollViewRect.height) )
                         {
+                            previewCount++;
+                            m_Tiles[idx].RenderPreview();
+                            m_TileContentText.image = m_Tiles[idx].Preview;
+                            m_TileContentText.tooltip = $"{m_Tiles[idx].materialName}\n\nClick to apply to the currently selected surface.";
+
                             SetButtonStyleBG( in idx );
 
                             //Debug.Log( $"IsInView for element {idx} is true, show thumbnail for material {m_Tiles[idx].materialName}" );
@@ -394,6 +397,9 @@ namespace Chisel.Editors
 
                     // end horizontal
                 }
+
+                AssetPreview.SetPreviewTextureCacheSize(previewCount + 1);
+
             }
             GUI.EndScrollView();
 

--- a/Packages/com.chisel.editor/Chisel/Editor/Editor/MaterialBrowser/ChiselMaterialThumbnailRenderer.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Editor/MaterialBrowser/ChiselMaterialThumbnailRenderer.cs
@@ -27,6 +27,7 @@ namespace Chisel.Editors
             // used for debug
             public string taskName;
 
+            public Action     StartWith    { get; }
             public Func<bool> Completed    { get; }
             public Action     ContinueWith { get; }
 
@@ -40,10 +41,11 @@ namespace Chisel.Editors
 
         private static readonly List<RenderJob> jobs = new List<RenderJob>();
 
-        public static void Add( string name, Func<bool> completed, Action continueWith )
+        public static void Add( string name, Action startWith, Func<bool> completed, Action continueWith )
         {
             if( !jobs.Any() ) EditorApplication.update += Update;
             jobs.Add( new RenderJob( name, completed, continueWith ) );
+            startWith?.Invoke();
         }
 
         private static void Update()


### PR DESCRIPTION
New behavior will request to render the preview thumbnail if the material is visible and if it's currently null or the default texture for material previews.

It might be ok to go back to rendering all previews and avoid the previews loading while scrolling around, but at least now it seems consistent.

Few bug fixes also:
OnDisable clears m_Tiles and m_Labels rather than nulls to avoid nre
Pass scroll rect height to GetVisible for accurate result
Dispose tiles in GetMaterials before clearing the list

